### PR TITLE
Mzweb 523

### DIFF
--- a/src/functions/post_confirmation/core/users/__init__.py
+++ b/src/functions/post_confirmation/core/users/__init__.py
@@ -20,9 +20,15 @@ def get_random_string(length):
     :param length:
     :return:
     """
-    letters = string.ascii_lowercase + string.digits
-    result_str = ''.join(random.choice(letters) for i in range(length))
-    return result_str
+    letters_length = length - 1
+    digits_length = 1
+
+    letters = string.ascii_lowercase
+    digits = string.digits
+
+    letters_string = ''.join(random.choices(letters, k=letters_length))
+    digits_string = ''.join(random.choices(digits, k=digits_length))
+    return letters_string + digits_string
 
 
 def list_similar_users(client, user_pool_id, email, username):


### PR DESCRIPTION
# Description

Modify the `get_random_string_ to return a combination of `length-1` characters, and `1` digit, to handle cognito password policy. 

Fixes # (issue)
https://jira.weart.io/browse/MZWEB-523

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Function tested locally.

# Checklist:

- [x] Modify the `get_random_string` to return characters and one digit.